### PR TITLE
Dæmon | Make top mip-level renormalization an opt-out option

### DIFF
--- a/crnlib/crn_mipmapped_texture.h
+++ b/crnlib/crn_mipmapped_texture.h
@@ -223,6 +223,7 @@ class mipmapped_texture {
           m_wrapping(false),
           m_srgb(false),
           m_renormalize(false),
+          m_rtopmip(false),
           m_filter_scale(.9f),
           m_gamma(1.75f),  // or 2.2f
           m_multithreaded(true) {
@@ -232,6 +233,7 @@ class mipmapped_texture {
     bool m_wrapping;
     bool m_srgb;
     bool m_renormalize;
+    bool m_rtopmip;
     float m_filter_scale;
     float m_gamma;
     bool m_multithreaded;

--- a/crnlib/crn_texture_comp.cpp
+++ b/crnlib/crn_texture_comp.cpp
@@ -374,7 +374,7 @@ bool create_texture_mipmaps(mipmapped_texture& work_tex, const crn_comp_params& 
   new_width = math::clamp<int>(new_width, 1, cCRNMaxLevelResolution);
   new_height = math::clamp<int>(new_height, 1, cCRNMaxLevelResolution);
 
-  if ((new_width != (int)work_tex.get_width()) || (new_height != (int)work_tex.get_height())) {
+  if ((new_width != (int)work_tex.get_width()) || (new_height != (int)work_tex.get_height()) || (mipmap_params.m_renormalize == true && mipmap_params.m_rtopmip == true)) {
     console::info("Resampling input texture to %ux%u", new_width, new_height);
 
     const char* pFilter = crn_get_mip_filter_name(mipmap_params.m_filter);

--- a/crnlib/crn_texture_conversion.cpp
+++ b/crnlib/crn_texture_conversion.cpp
@@ -346,6 +346,7 @@ static void print_mipmap_params(const crn_mipmap_params& mipmap_params) {
   console::debug("Gamma filtering: %u, Gamma: %2.2f", mipmap_params.m_gamma_filtering, mipmap_params.m_gamma);
   console::debug("     Blurriness: %2.2f", mipmap_params.m_blurriness);
   console::debug("    Renormalize: %u", mipmap_params.m_renormalize);
+  console::debug("Renorm. top mip: %u", mipmap_params.m_rtopmip);
   console::debug("          Tiled: %u", mipmap_params.m_tiled);
   console::debug("     Max Levels: %u", mipmap_params.m_max_levels);
   console::debug(" Min level size: %u", mipmap_params.m_min_mip_size);

--- a/crunch/crunch.cpp
+++ b/crunch/crunch.cpp
@@ -140,6 +140,7 @@ class crunch {
     console::printf("-blurriness # - Scale filter kernel, >1=blur, <1=sharpen, .01-8, default=.9");
     console::printf("-wrap - Assume texture is tiled when filtering, default=clamping");
     console::printf("-renormalize - Renormalize filtered normal map texels, default=disabled");
+    console::printf("-rtopmip - Renormalize on the top mip-level too, default=disabled");
     console::printf("-maxmips # - Limit number of generated texture mipmap levels, 1-16, default=16");
     console::printf("-minmipsize # - Smallest allowable mipmap resolution, default=1");
 
@@ -208,6 +209,7 @@ class crunch {
             {"blurriness", 1, false},
             {"wrap", 0, false},
             {"renormalize", 0, false},
+            { "rtopmip", 0, false },
             {"noprogress", 0, false},
             {"paramdebug", 0, false},
             {"debug", 0, false},
@@ -700,6 +702,7 @@ class crunch {
     mip_params.m_blurriness = m_params.get_value_as_float("blurriness", 0, mip_params.m_blurriness, .01f, 8.0f);
 
     mip_params.m_renormalize = m_params.get_value_as_bool("renormalize", 0, mip_params.m_renormalize != 0);
+    mip_params.m_rtopmip = m_params.get_value_as_bool("rtopmip", 0, mip_params.m_rtopmip != 0);
     mip_params.m_tiled = m_params.get_value_as_bool("wrap");
 
     mip_params.m_max_levels = m_params.get_value_as_int("maxmips", 0, cCRNMaxLevels, 1, cCRNMaxLevels);

--- a/inc/crnlib.h
+++ b/inc/crnlib.h
@@ -415,6 +415,7 @@ struct crn_mipmap_params {
     // Default "blurriness" factor of .9 actually sharpens the output a little.
     m_blurriness = .9f;
     m_renormalize = false;
+    m_rtopmip = false;
     m_tiled = false;
     m_max_levels = cCRNMaxLevels;
     m_min_mip_size = 1;
@@ -448,6 +449,7 @@ struct crn_mipmap_params {
     CRNLIB_COMP(m_gamma);
     CRNLIB_COMP(m_blurriness);
     CRNLIB_COMP(m_renormalize);
+    CRNLIB_COMP(m_rtopmip);
     CRNLIB_COMP(m_tiled);
     CRNLIB_COMP(m_max_levels);
     CRNLIB_COMP(m_min_mip_size);
@@ -478,6 +480,7 @@ struct crn_mipmap_params {
   crn_uint32 m_min_mip_size;
 
   crn_bool m_renormalize;
+  crn_bool m_rtopmip;
   crn_bool m_tiled;
 
   crn_scale_mode m_scale_mode;


### PR DESCRIPTION
Until now at [Unvanquished](http://github.com/Unvanquished/Unvanquished/), we used an [old crunch fork](https://github.com/Unvanquished/crunch) that was patched by @gimhael on this purpose, he said in that time:

> Some tools scale the vectors in normalmaps to maximum length for
> increased precision, but that breaks reconstruction of the z part
> in DXN compressed normal maps. Passing -renormalize on compression
> fixes those textures now.

This PR reports the change to upstream, making it as an opt-out option to not change the default `-renormalize` behavior.

Users can do `crunch -renormalize -rtopmip` to get the behavior they need.

---
patch from https://github.com/DaemonEngine/crunch