### PR TITLE
crunch: Return NULL instead of false when the function expects a pointer

### DIFF
--- a/inc/crn_decomp.h
+++ b/inc/crn_decomp.h
@@ -2323,11 +2323,11 @@ const void* crnd_get_level_data(const void* pData, uint32 data_size, uint32 leve
 
 uint32 crnd_get_segmented_file_size(const void* pData, uint32 data_size) {
   if ((!pData) || (data_size < cCRNHeaderMinSize))
-    return false;
+    return NULL;
 
   const crn_header* pHeader = crnd_get_header(pData, data_size);
   if (!pHeader)
-    return false;
+    return NULL;
 
   uint32 size = pHeader->m_header_size;
 


### PR DESCRIPTION
Import some fixes by @DolceTriade from [Unvanquished's fork](https://github.com/Unvanquished/crunch).

Original commit (Unvanquished/crunch@e4f056c) included more change, but it was targetting an old branch and it looks like the 2/3 of the fixes are already done upstream thanks to some other people, so this is just the remaining fixes.