### PR TITLE
Dæmon | f1d6a5a removed crn_zeng code, do not attempt to build it

### DIFF
--- a/crnlib/Makefile
+++ b/crnlib/Makefile
@@ -51,7 +51,6 @@ OBJECTS = \
   crn_utils.o \
   crn_value.o \
   crn_vector.o \
-  crn_zeng.o \
   crn_texture_comp.o \
   crn_texture_conversion.o \
   crn_dds_comp.o \

--- a/crnlib/crnlib.cbp
+++ b/crnlib/crnlib.cbp
@@ -189,8 +189,6 @@
 		<Unit filename="crn_vector.h" />
 		<Unit filename="crn_vector2d.h" />
 		<Unit filename="crn_winhdr.h" />
-		<Unit filename="crn_zeng.cpp" />
-		<Unit filename="crn_zeng.h" />
 		<Unit filename="crnlib.cbp" />
 		<Unit filename="crnlib.cpp" />
 		<Unit filename="lzma_7zBuf.cpp" />

--- a/crnlib/crnlib_linux.cbp
+++ b/crnlib/crnlib_linux.cbp
@@ -189,8 +189,6 @@
 		<Unit filename="crn_vector.h" />
 		<Unit filename="crn_vector2d.h" />
 		<Unit filename="crn_winhdr.h" />
-		<Unit filename="crn_zeng.cpp" />
-		<Unit filename="crn_zeng.h" />
 		<Unit filename="crnlib.cbp" />
 		<Unit filename="crnlib.cpp" />
 		<Unit filename="lzma_7zBuf.cpp" />


### PR DESCRIPTION
f1d6a5a removed crn_zeng code, but only visual studio stuff was adapted to not require it to be built anymore, now fixed.

---
patch from https://github.com/DaemonEngine/crunch