### PR TITLE
Fix switch fall-through in crn_decompress_block

### DIFF
--- a/crnlib/crnlib.cpp
+++ b/crnlib/crnlib.cpp
@@ -386,6 +386,8 @@ bool crn_decompress_block(const void* pSrc_block, crn_uint32* pDst_pixels_u32, c
         pDst_pixels[i] = colors[s];
         pDst_pixels[i].a = static_cast<uint8>(values[a]);
       }
+      
+      break;
     }
 
     case cCRNFmtDXN_XY:


### PR DESCRIPTION
Do not immediately overwrite our DXT5-decompressed pixels with a cCRNFmtDXN_XY interpretation.