### PR TITLE
Remove std allocation

### DIFF
--- a/crnlib/allocator.h
+++ b/crnlib/allocator.h
@@ -13,12 +13,12 @@ namespace crnlib
 
         value_type* allocate(std::size_t n)
         {
-            return static_cast<T*>(crnlib_malloc(n));
+            return static_cast<T*>(crnlib_malloc(n * sizeof(T)));
         }
         
         void deallocate(value_type* p, std::size_t) noexcept 
         {
-            crnlib_free(p);
+            crnlib_delete(p);
         }
     };
 

--- a/crnlib/allocator.h
+++ b/crnlib/allocator.h
@@ -18,7 +18,7 @@ namespace crnlib
         
         void deallocate(value_type* p, std::size_t) noexcept 
         {
-            crnlib_delete(p);
+            crnlib_free(p);
         }
     };
 

--- a/crnlib/allocator.h
+++ b/crnlib/allocator.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "crn_mem.h"
+
+namespace crnlib
+{
+    template <class T>
+    class allocator
+    {
+    public:
+        using value_type = T;
+        template <class U> allocator(allocator<U> const&) noexcept {}
+        allocator() noexcept {};
+
+        value_type* allocate(std::size_t n)
+        {
+            return static_cast<T*>(crnlib_malloc(n));
+        }
+        
+        void deallocate(value_type* p, std::size_t) noexcept 
+        {
+            crnlib_free(p);
+        }
+    };
+
+    template <class T, class U>
+    bool operator==(allocator<T> const&, allocator<U> const&) noexcept
+    {
+        return true;
+    }
+
+    template <class T, class U>
+    bool operator!=(allocator<T> const& x, allocator<U> const& y) noexcept
+    {
+        return !(x == y);
+    }
+}

--- a/crnlib/crn_dxt_hc.cpp
+++ b/crnlib/crn_dxt_hc.cpp
@@ -716,7 +716,7 @@ void dxt_hc::determine_color_endpoints() {
     m_pTask_pool->queue_task(&Node::sort_task, i, &nodes[i]);
   m_pTask_pool->join();
 
-  std::priority_queue<Node> queue;
+  std::priority_queue<Node, std::vector<Node, allocator<Node>>> queue;
   for (uint i = 0; i < nodes.size(); i++)
     queue.push(nodes[i]);
 
@@ -1055,7 +1055,7 @@ void dxt_hc::create_color_selector_codebook() {
     m_pTask_pool->queue_task(&SelectorNode::sort_task, i, &nodes[i]);
   m_pTask_pool->join();
 
-  std::priority_queue<SelectorNode> queue;
+  std::priority_queue<SelectorNode, std::vector<SelectorNode, allocator<SelectorNode>>> queue;
   for (uint i = 0; i < nodes.size(); i++)
     queue.push(nodes[i]);
 
@@ -1213,7 +1213,7 @@ void dxt_hc::create_alpha_selector_codebook() {
     m_pTask_pool->queue_task(&SelectorNode::sort_task, i, &nodes[i]);
   m_pTask_pool->join();
 
-  std::priority_queue<SelectorNode> queue;
+  std::priority_queue<SelectorNode, std::vector<SelectorNode, allocator<SelectorNode>>> queue;
   for (uint i = 0; i < nodes.size(); i++)
     queue.push(nodes[i]);
 

--- a/crnlib/crnlib.2010.vcxproj
+++ b/crnlib/crnlib.2010.vcxproj
@@ -550,6 +550,7 @@
     <ClInclude Include="crn_dxt_image.h" />
     <ClInclude Include="crn_ktx_texture.h" />
     <ClInclude Include="crn_mipmapped_texture.h" />
+    <ClInclude Include="allocator.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
std::priority_queue creates an internal std::vector with a default allocator. This bypasses the alloc function passed to the lib via crn_set_memory_callbacks