### PR TITLE
Dæmon | fix malloc in crn_decomp single header file on FreeBSD

### DIFF
--- a/inc/crn_decomp.h
+++ b/inc/crn_decomp.h
@@ -19,6 +19,9 @@
 #include <stdio.h>
 #ifdef WIN32
 #include <memory.h>
+#elif defined(__FreeBSD__)
+// <malloc.h> has been replaced by <stdlib.h>
+#include <malloc_np.h> // for malloc_usable_size
 #else
 #include <malloc.h>
 #endif


### PR DESCRIPTION
This only enables third-party project to support crnlib decompression on FreeBSD, this is not enough to build the `crunch` tool on FreeBSD. See #7 for similar patch on macOS.